### PR TITLE
Fix `opam remove rlp`

### DIFF
--- a/opam
+++ b/opam
@@ -13,7 +13,7 @@ build: [
   ["ocaml" "setup.ml" "-doc"]
 ]
 install: ["ocaml" "setup.ml" "-install"]
-remove: ["ocaml" "setup.ml" "-uninstall"]
+remove: ["ocamlfind" "remove" "rlp"]
 depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}


### PR DESCRIPTION
Before this change, `opam remove` didn't remove `META` file from `.opam` directory.
That caused an error in the next `opam install`.

```
\#=== ERROR while installing rlp.0.1 ===========================================#
\# opam-version 1.2.2
\# os           linux
\# command      ocaml setup.ml -install
\# path         /home/yh/.opam/4.04.2/build/rlp.0.1
\# compiler     4.04.2
\# exit-code    1
\# env-file     /home/yh/.opam/4.04.2/build/rlp.0.1/rlp-31198-d2c37b.env
\# stdout-file  /home/yh/.opam/4.04.2/build/rlp.0.1/rlp-31198-d2c37b.out
\# stderr-file  /home/yh/.opam/4.04.2/build/rlp.0.1/rlp-31198-d2c37b.err
\### stderr ###
\# ocamlfind: Package rlp is already installed
\#  - (file /home/yh/.opam/4.04.2/lib/rlp/META already exists)
```